### PR TITLE
two small fixes

### DIFF
--- a/lib/Zabbix/API.pm
+++ b/lib/Zabbix/API.pm
@@ -3,6 +3,7 @@ package Zabbix::API;
 use strict;
 use warnings;
 use 5.010;
+use experimental qw< switch >;
 
 use Params::Validate qw/:all/;
 use Carp qw/carp croak confess cluck/;

--- a/lib/Zabbix/API.pm
+++ b/lib/Zabbix/API.pm
@@ -151,6 +151,9 @@ sub raw_query {
     $args{'jsonrpc'} = '2.0';
     $args{'auth'} = $self->cookie || '';
     $args{'id'} = $global_id++;
+    $args{'params'} //= {};
+    delete $args{'auth'}
+        if grep /^$args{method}$/, qw< user.login apiinfo.version >;
 
     my $response = eval { $self->{ua}->post($self->{server},
                                             'Content-Type' => 'application/json-rpc',


### PR DESCRIPTION
+ The first is to avoid the warnings about `given` & `when` emitted by recent versions of Perl. A dependency on the [`experimental`](https://metacpan.org/pod/experimental) module can be added as well, given it is available on the CPAN with low prereqs itself.
+ The second is to allow the `api_version` method to work.